### PR TITLE
docs(gemini): cover thinking, grounding, compositional editing across all surfaces

### DIFF
--- a/docs/MCP_EXAMPLES.md
+++ b/docs/MCP_EXAMPLES.md
@@ -174,6 +174,96 @@ Note: This requires Vertex AI authentication. The result will be higher quality 
 
 ---
 
+## Gemini 3+ Advanced Features (Compositional Editing, Thinking, Grounding)
+
+These three capabilities are exclusive to Gemini 3+ models (`gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview`). They are silently ignored on other providers, so passing them is always safe.
+
+### Example 7a: Compositional Editing with One Reference Image
+
+**User Prompt:**
+```
+I have a product photo at ~/Pictures/sneaker.png. Place it on a marble counter under soft studio lighting and save the result to ~/Desktop/sneaker-styled.png.
+```
+
+**Claude's Actions:**
+```
+Using Gemini 3.1 Flash for Nano Banana-style compositional editing.
+
+[Calls generate_image with prompt="place this product on a marble counter, soft three-point studio light, shallow depth of field", model="gemini-3.1-flash-image-preview", input_images=["~/Pictures/sneaker.png"], image_size="2K", output="~/Desktop/sneaker-styled.png"]
+
+The original product is preserved in the composition; only the environment and lighting are generated.
+```
+
+**Result:**
+The original sneaker stays visually consistent and appears on a freshly-generated marble background with the requested lighting.
+
+---
+
+### Example 7b: Multi-Reference Composition
+
+**User Prompt:**
+```
+Combine these three reference images — a character (character.png), a background scene (forest.jpg), and a prop (sword.png) — into a single cinematic shot of the character in the forest holding the sword.
+```
+
+**Claude's Actions:**
+```
+Using Gemini 3.1 Flash with three reference images for multi-object composition. The model can take up to 14 references on this variant.
+
+[Calls generate_image with prompt="this character standing in this forest holding this sword, cinematic lighting, low angle, dramatic shadows", model="gemini-3.1-flash-image-preview", input_images=["character.png", "forest.jpg", "sword.png"], aspect_ratio="16:9", output="~/Desktop/composed.png"]
+
+All three references contribute to the composition. The prompt describes how to combine them, not what they look like.
+```
+
+**Per-model caps**: Gemini 2.5 Flash=3, Gemini 3 Pro=11, Gemini 3.1 Flash=14. Exceeding the cap returns a clear error before any HTTP call.
+
+---
+
+### Example 7c: Thinking Mode for Complex Layouts
+
+**User Prompt:**
+```
+Generate a Q3 2026 revenue infographic with these data points: revenue up 18%, gross margin up 4pp, 3 new product launches. Use a clean corporate style with the company colors navy and gold.
+```
+
+**Claude's Actions:**
+```
+This is a text-heavy multi-element layout — exactly where thinking mode pays off. Using Gemini 3 Pro at 4K with high thinking level for careful text rendering and composition planning.
+
+[Calls generate_image with prompt="corporate infographic for Q3 2026: 'Revenue up 18%' as headline, three labeled sections — 'Gross Margin +4pp', '3 New Product Launches', and a small trend chart. Navy and gold palette, modern sans-serif typography, clean white background", model="gemini-3-pro-image-preview", image_size="4K", thinking="high", output="~/Desktop/q3-infographic.png"]
+
+Higher thinking levels add latency but materially improve text legibility and element alignment on dense layouts.
+```
+
+**When to use each level**:
+- `minimal`: high-volume cost-sensitive workloads, single-subject illustrations
+- `low` (default): casual generation, stylistic exploration
+- `medium`: layouts with multiple labeled elements
+- `high`: text-heavy assets, precise compositions, UI mockups
+
+---
+
+### Example 7d: Google Search Grounding for Current References
+
+**User Prompt:**
+```
+Generate an official-looking product photo of the Nintendo Switch 2 console, front view, white background. Make sure the design is accurate to the current release.
+```
+
+**Claude's Actions:**
+```
+The user wants an accurate rendering of a real product. Enabling Google Search grounding so Gemini can pull current visual references before generating. Note: each search query inside grounding is billed in addition to the image cost.
+
+[Calls generate_image with prompt="Nintendo Switch 2 console, front view, white background, product photography style", model="gemini-3-pro-image-preview", grounding=true, output="~/Desktop/switch2.png"]
+
+Grounding is most useful for products, public figures, and landmarks where visual accuracy matters. For pure imagination prompts, skip it to avoid the extra search billing.
+```
+
+**Result:**
+The generated image matches the official Switch 2 design rather than hallucinating an imagined version.
+
+---
+
 ## Image Processing Pipelines
 
 ### Example 8: Prepare Photo for Instagram

--- a/docs/PROMPT_GUIDE.md
+++ b/docs/PROMPT_GUIDE.md
@@ -85,6 +85,83 @@ Structure prompts with studio details:
 gimage generate "luxury wristwatch with rose gold case and black leather strap, positioned at 45-degree angle on white marble surface, three-point softbox lighting, macro detail on watch face, clean white background"
 ```
 
+## Gemini 3+ Advanced Features
+
+These flags are exclusive to Gemini 3+ models (`gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview`). They are silently ignored on Gemini 2.5 Flash and non-Gemini providers, so it's safe to leave them in your default invocation.
+
+### Compositional Editing with Reference Images
+
+Pass one or more reference images via `--input-image` (repeatable) for Nano Banana-style compositional editing. The prompt then describes how to combine or transform them. Per-model caps: Gemini 2.5 Flash=3, Gemini 3 Pro=11, Gemini 3.1 Flash=14. PNG/JPEG/WebP only; each file is capped at 20 MB.
+
+```bash
+# Drop a product into a new scene
+gimage generate "place this product on a marble counter, soft studio light" \
+  --model gemini-3.1-flash --input-image product.png
+
+# Combine a character and a background
+gimage generate "this character standing in this environment, cinematic lighting" \
+  --model gemini-3-pro --input-image character.png --input-image scene.jpg
+
+# Multi-object composition (Gemini 3.1 Flash, up to 14 refs)
+gimage generate "an office group photo of these people making funny faces" \
+  --model gemini-3.1-flash \
+  --input-image person1.png --input-image person2.png --input-image person3.png
+```
+
+**Tips:**
+- The prompt should describe the *transformation*, not re-describe the references — the model already sees them.
+- For "place X in Y" tasks, the FIRST reference image tends to anchor as the subject.
+- Empty / whitespace-only paths are silently dropped, so it's safe to wire this through scripts that may not always have a reference.
+
+### Thinking Mode
+
+Gemini 3+ models can be told how much to "think" before generating. Higher levels improve layout, text rendering, and prompt adherence at the cost of latency.
+
+```bash
+# Low (default): fast, good for casual generation
+gimage generate "abstract poster"
+
+# Medium: better for layouts with multiple elements
+gimage generate "menu board with 5 items and prices" --thinking medium
+
+# High: best for text-heavy or complex composition
+gimage generate "infographic: 'Q3 revenue up 18%' with 4 bullet points" \
+  --model gemini-3-pro --image-size 4K --thinking high
+```
+
+**When to dial it up:**
+- Text-heavy assets (logos, posters, infographics, menus)
+- Complex multi-element compositions
+- Geometric or precise layout (UI mockups, diagrams)
+
+**When to leave it at default (or `minimal`):**
+- Single-subject illustrations
+- Stylistic exploration (you want creative variance, not careful planning)
+- High-volume / cost-sensitive workloads
+
+### Google Search Grounding
+
+Enable `--grounding` to let Gemini pull real-time visual references from the web before generating. Billed per search query in addition to the per-image cost. Useful when the prompt references current entities (products, news, brands, places).
+
+```bash
+# Generate based on current real-world visual references
+gimage generate "official Nintendo Switch 2 console front view, white background" \
+  --model gemini-3-pro --grounding
+
+# Anchor a stylized version to a real reference
+gimage generate "watercolor painting of the Sydney Opera House at sunset" \
+  --model gemini-3.1-flash --grounding
+```
+
+**When grounding helps:**
+- Real products with specific brand visuals
+- Recent / topical references (recently released games, current events)
+- Public figures or landmarks where accuracy matters
+
+**When to skip it:**
+- Pure imagination / fantasy prompts (no real-world anchor needed)
+- Prompts where the per-search billing isn't justified
+
 ## Quick Reference
 
 ### Transform Weak Prompts

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -1160,6 +1160,36 @@ func printPromptHowto() error {
 └─────────────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────────────┐
+│ GEMINI 3+ ADVANCED FEATURES (silently ignored on other models)                  │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                 │
+│ Compositional editing (Nano Banana style): pass one or more reference images    │
+│ via --input-image and describe the transformation in the prompt.                │
+│   Caps: Gemini 2.5 Flash=3, Gemini 3 Pro=11, Gemini 3.1 Flash=14                 │
+│   Formats: PNG, JPEG, WebP. Each image capped at 20 MB.                         │
+│                                                                                 │
+│   gimage generate "place this on a marble counter, soft studio light" \         │
+│     --model gemini-3.1-flash --input-image product.png                          │
+│                                                                                 │
+│   gimage generate "this character in this scene, cinematic lighting" \          │
+│     --model gemini-3-pro --input-image character.png --input-image scene.jpg    │
+│                                                                                 │
+│ Thinking mode: dial up reasoning depth for text-heavy or complex layouts.       │
+│   Levels: minimal | low (default) | medium | high                               │
+│   Higher = better layout/text, slightly slower.                                 │
+│                                                                                 │
+│   gimage generate "Q3 infographic 'Revenue +18%'" \                             │
+│     --model gemini-3-pro --image-size 4K --thinking high                        │
+│                                                                                 │
+│ Google Search grounding: enable for accurate renders of real-world entities.    │
+│   Billed per search query in addition to the per-image cost.                    │
+│                                                                                 │
+│   gimage generate "official Nintendo Switch 2 console front view" \             │
+│     --model gemini-3-pro --grounding                                            │
+│                                                                                 │
+└─────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────┐
 │ TIPS FOR BETTER RESULTS                                                         │
 ├─────────────────────────────────────────────────────────────────────────────────┤
 │                                                                                 │

--- a/mcp.md
+++ b/mcp.md
@@ -47,7 +47,7 @@ The server exposes 10 tools covering all gimage operations. For a complete param
 
 ### 1. Image Generation
 
-- `generate_image`: Generate AI images from text prompts.
+- `generate_image`: Generate AI images from text prompts. Gemini 3+ models additionally support `input_images` (Nano Banana compositional editing — up to 3/11/14 reference images depending on model), `thinking` (reasoning depth: `minimal|low|medium|high`), and `grounding` (Google Search grounding for current/real references).
 - `list_models`: List available providers, models, and pricing.
 
 ### 2. Single Image Processing

--- a/sdk/go/EXAMPLE.md
+++ b/sdk/go/EXAMPLE.md
@@ -143,11 +143,38 @@ func main() {
 		fmt.Printf("  Size: %dx%d\n\n", result.Width, result.Height)
 	}
 
+	// Example 4: Gemini 3+ compositional editing with reference images + thinking
+	fmt.Println("4. Compositional editing with Gemini 3.1 Flash...")
+	thinkingLevel := gimage.GenerateRequestThinkingLevelLow
+	composeResp, err := client.GenerateImage(ctx, gimage.GenerateImageJSONRequestBody{
+		Prompt:        "place this character on a beach at golden hour, cinematic lighting",
+		Model:         stringPtr("gemini-3.1-flash-image-preview"),
+		ImageSize:     stringPtr("2K"),
+		AspectRatio:   stringPtr("16:9"),
+		// InputImages on the wire are local paths the server reads; for the
+		// HTTP API surface this field is expected as a string slice — see
+		// the OpenAPI spec for the deployment-specific convention.
+		InputImages:   &[]string{"/path/to/character.png"},
+		ThinkingLevel: &thinkingLevel,
+		Grounding:     boolPtr(false), // enable for current/real-world references
+	})
+	if err != nil {
+		log.Fatalf("Compositional edit failed: %v", err)
+	}
+	defer composeResp.Body.Close()
+	if composeResp.StatusCode == 200 {
+		fmt.Println("✓ Compositional edit complete (Gemini 3+ exclusive — silently ignored on other providers)")
+	}
+
 	fmt.Println("✓ All examples completed successfully!")
 }
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 ```
 


### PR DESCRIPTION
## Summary

- v1.2.129 shipped three Gemini-only flags (`--thinking`, `--grounding`, `--input-image`) but only the primary user-facing docs were updated. This catches the remaining surfaces so users land on consistent guidance regardless of where they look.
- No production code changed — only the inline `--prompt-howto` help string in `internal/cli/generate.go`. CLI tests pass and the new help section renders correctly.

## Docs updated

| File | Change |
|------|--------|
| `docs/MCP_EXAMPLES.md` | New "Gemini 3+ Advanced Features" subsection with 4 examples (single-ref edit, multi-ref composition, thinking for layouts, grounding for current references). Slotted between Example 7 and the next section so existing example numbering stays stable. |
| `docs/PROMPT_GUIDE.md` | New top-level section with three sub-sections (Reference Images, Thinking Mode, Grounding) including when-to-use / when-to-skip guidance. |
| `internal/cli/generate.go` (`--prompt-howto`) | New boxed "GEMINI 3+ ADVANCED FEATURES" section in the inline help, between SIZE & ASPECT RATIO and TIPS FOR BETTER RESULTS. |
| `mcp.md` | `generate_image` bullet now mentions the new parameters inline. Tool count unchanged. |
| `sdk/go/EXAMPLE.md` | New Example 4 demonstrating `GenerateRequestThinkingLevel`, `InputImages`, and `Grounding` via the generated SDK types. Added a `boolPtr` helper. |

## Test plan

- [x] `go test ./internal/cli/...` passes
- [x] `make build` succeeds
- [x] `./bin/gimage generate --prompt-howto` renders the new section between SIZE & ASPECT RATIO and TIPS FOR BETTER RESULTS
- [x] markdown spot-checked for broken anchors and consistent voice across files

## Why no release bump

These changes don't affect the binary's behavior — only the help text inside it and the markdown files in the repo. The next time someone runs `make release` for an unrelated change, this content gets bundled automatically. Filing as docs-only avoids burning a release version on a CHANGELOG-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)