### PR TITLE
Align Go toolchain + CI to 1.26, un-pin @latest tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,26 +15,26 @@ jobs:
     environment: apresai  # Access HOMEBREW_TAP_TOKEN from this environment
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod  # single source of truth; no drift from a hardcoded pin
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'  # Includes npm 11.6+ with OIDC support
           registry-url: 'https://registry.npmjs.org'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"  # major-pinned; avoids a surprise roll to goreleaser v3
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 - AWS Lambda API deployment
 
 **Technology Stack**:
-- Pure Go 1.22+ (zero C dependencies for portability)
+- Pure Go 1.26+ (zero C dependencies for portability)
 - Image processing: `github.com/disintegration/imaging`
 - CLI: Cobra + Viper
 - APIs: Gemini API, Vertex AI, xAI Grok
@@ -691,7 +691,7 @@ gimage-deploy/           # Deployment management tool (separate repo)
 ### Architecture
 
 **Technology Stack**:
-- Pure Go 1.22+
+- Pure Go 1.26+
 - AWS SDK v2 (Lambda, S3, IAM, API Gateway, CloudWatch, STS)
 - Cobra for CLI framework
 - Bubbletea for TUI

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ lint:
 	@if command -v $(GOLINT) > /dev/null; then \
 		$(GOLINT) run ./...; \
 	else \
-		echo "golangci-lint not installed. Install with: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"; \
+		echo "golangci-lint not installed. Install with: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2"; \
 		exit 1; \
 	fi
 
@@ -475,7 +475,10 @@ SDK_PKG=github.com/apresai/gimage/sdk/go
 ## install-sdk-tools: Install oapi-codegen for SDK generation
 install-sdk-tools:
 	@echo "Installing oapi-codegen..."
-	@go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	@# Pinned to the version that generated the committed sdk/go/*.gen.go so
+	@# `make generate-sdk` stays reproducible. Bumping to v2.7.x (breaking output
+	@# changes + Go 1.24 min) is a deliberate, separate regeneration PR.
+	@go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.5.1
 	@echo "✓ SDK tools installed"
 
 ## generate-sdk: Generate Go SDK from OpenAPI spec

--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ make package-lambda
 - AWS Account
 - AWS CLI configured
 - Node.js 20+ (for CDK deployment)
-- Go 1.22+ (for building)
+- Go 1.26+ (for building)
 
 ## Support & Documentation
 

--- a/gimage-deploy/go.mod
+++ b/gimage-deploy/go.mod
@@ -1,6 +1,8 @@
 module github.com/apresai/gimage-deploy
 
-go 1.25.0
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/apresai/gimage
 
-go 1.25.3
+go 1.26
+
+toolchain go1.26.4
 
 require (
 	github.com/HugoSmits86/nativewebp v1.3.0

--- a/mcp.md
+++ b/mcp.md
@@ -1,7 +1,7 @@
 # Gimage MCP Server
 
 **Version**: 1.2.99+ (see CHANGELOG.md for current version)
-**Runtime**: Go 1.22+
+**Runtime**: Go 1.26+
 **Protocol**: Model Context Protocol (stdio transport)
 
 ---

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,6 +1,8 @@
 module github.com/apresai/gimage/sdk/go
 
-go 1.22.5
+go 1.26
+
+toolchain go1.26.4
 
 require github.com/getkin/kin-openapi v0.135.0
 


### PR DESCRIPTION
## What

Toolchain/CI hygiene — **no application logic changes**. Fixes a three-way Go-version drift and removes the `@latest` pins that violate the repo's "never `@latest`" rule. PR 2 of 3 in the SDK/dependency-freshness sweep (follows #9).

### Go version alignment (all three modules → one current version)
- `go.mod` 1.25.3, `sdk/go/go.mod` 1.22.5 (EOL), `gimage-deploy/go.mod` 1.25.0 → **`go 1.26` + `toolchain go1.26.4`** across all three. 1.22/1.24 are EOL; 1.26 matches local dev and current stable.

### CI (`.github/workflows/release.yml`)
- `setup-go`: hardcoded `go-version: '1.22'` (dead config — GOTOOLCHAIN auto-download was silently upgrading it) → **`go-version-file: go.mod`**, so CI can't drift from the module's declared version again.
- Action majors → current (all safe on `ubuntu-latest`): `checkout@v4→v7`, `setup-go@v5→v6`, `setup-node@v4→v6`, `goreleaser-action@v6→v7`.
- goreleaser CLI `version: latest` → **`"~> v2"`** (major-pinned; prevents a surprise roll to v3).

### Makefile (`@latest` → pinned)
- `install-sdk-tools`: `oapi-codegen@latest` → **`@v2.5.1`** (the version that generated the committed `sdk/go/*.gen.go`, keeping `make generate-sdk` reproducible). The v2.7.x jump has breaking generated-output changes → deferred regeneration PR.
- lint help text: `golangci-lint@latest` → v2 module path `@v2.12.2`.

### Docs
- Updated the now-stale "Go 1.22+" build/runtime claims (README, mcp.md, CLAUDE.md ×2) → "Go 1.26+". Left the CHANGELOG's historical "Built with Go 1.22+" entry as-is.

## Verification
- All three modules `go build` + `go test` under go 1.26
- `govulncheck` clean
- `goreleaser build --snapshot --clean` compiles both release binaries (tidy + test before-hooks green)

## Notes / follow-up
- `goreleaser check` surfaces a **pre-existing** `brews:` deprecation (not introduced here; protected by the `~> v2` pin). The Homebrew **formula → cask** migration is a distribution-behavior change → tracked as a follow-up, out of scope for this toolchain PR.

## Next
- **PR 3**: Charm bubbletea/bubbles/lipgloss v1→v2 migration (depends on this PR's Go 1.26 alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)