### PR TITLE
Remove dead xAI allowances from .gitallowed

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -7,14 +7,11 @@ VERTEX_API_KEY
 VERTEX_PROJECT
 VERTEX_LOCATION
 
-# Masked xAI Grok key placeholders used in documentation examples (not real keys).
-# Bare-prefix form so each allowance also matches its own line in this file.
-xai-5zM
-xai-your-key
-# Fake xAI Grok keys used as test fixtures in internal/config/config_test.go.
-xai-grok-key
-xai-test-grok-key
-xai-key-present
+# No xAI allowances needed: the git-secrets pattern is xai-[A-Za-z0-9]{20,}, and a real
+# key is the prefix plus 80 alphanumerics, so the doc placeholders and test fixtures here
+# (xai-5zM..., xai-your-key, xai-grok-key, xai-test-grok-key-123, xai-key-present) no
+# longer match. Do not reintroduce a loose xai-[a-zA-Z0-9_-]+ pattern.
+
 # Fake Google API-key placeholders used as test fixtures in internal/config/auth_test.go (not real keys).
 AIzaSyABCDEFGH
 AIzaSy_ABCDEFGH


### PR DESCRIPTION
## What

Drops the five xAI entries from `.gitallowed` (`xai-5zM`, `xai-your-key`, `xai-grok-key`, `xai-test-grok-key`, `xai-key-present`) and replaces them with a comment recording why none is needed. The `AIzaSy*` allowances stay.

## Why

The git-secrets pattern was tightened from `xai-[a-zA-Z0-9_-]+` to `xai-[A-Za-z0-9]{20,}`. A real xAI key is the `xai-` prefix plus 80 alphanumerics, while every placeholder and fixture in this repo has fewer than 20 alphanumerics after the prefix, so the pattern no longer fires on them and the allowances only obscure what is actually being suppressed.

The `AIzaSy` entries are a different story: that pattern is still the loose `AIzaSy[a-zA-Z0-9_-]+` form, so `AIzaSyABCDEFGH`, `AIzaSy_ABCDEFGH`, and `AIzaSyD1` do still match and their allowances remain load-bearing. Left in place.

## Verification

Effective pattern in this repo, then a full working-tree scan and a scan of every file that carried a removed allowance, both with the entries already deleted:

```
$ git config --get-all secrets.patterns | grep xai
xai-[A-Za-z0-9]{20,}

$ git secrets --scan
exit=0

$ git secrets --scan CLAUDE.md COMMANDS.md README.md \
    internal/config/auth_test.go internal/config/config_test.go .gitallowed
exit=0
```

Every line the removed entries used to cover is still present and now scans clean on its own:

```
CLAUDE.md:396:**grok_api_key**: xai-5zM...
COMMANDS.md:1086:| `GROK_API_KEY` | xAI Grok API key | `xai-5zM...` |
README.md:268:**grok_api_key**: xai-5zM...
README.md:302:export GROK_API_KEY="xai-your-key"
internal/config/auth_test.go:305:  t.Setenv("GROK_API_KEY", "xai-key-present")
internal/config/config_test.go:214:  t.Setenv("GROK_API_KEY", "xai-test-grok-key-123")
internal/config/config_test.go:218:  assert.Equal(t, "xai-test-grok-key-123", cfg.GrokAPIKey)
internal/config/config_test.go:310:**grok_api_key**: xai-grok-key
internal/config/config_test.go:327:  assert.Equal(t, "xai-grok-key", cfg.GrokAPIKey)
```

Detection is not weakened. A synthetic same-shape key (invented for this check, prefix plus 80 alphanumerics, not a credential) is still caught, and the benign identifiers sitting on the following line of the same file are not:

```
$ git secrets --scan /tmp/xai-shape-check.txt
xai-shape-check.txt:2:GROK_API_KEY="xai-FAKEFAKE...FAKE"

[ERROR] Matched one or more prohibited patterns
exit=1
```

No fixture, doc, or test content changed. Committed with hooks running, no `--no-verify`.